### PR TITLE
Tetris with its default shapes and rotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,11 @@ All notable changes to this project will be documented in this file.
 * User can speed up game via down arrow button on his keyboard
 * If any block reaches top of the tower, it will change color to red and pause game
 * Pause button (now Debug button) can only stop block in the air and pause game
+
+## 04.08.2024
+
+* Added shapes that contains blocks
+* All default Tetris shapes supported
+* Shapes cannot exceeded borders or go through others
+* Shapes are chosen randomly
+* After filling entire row, it is deleted and blocks above fall down by 1 block position

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,11 @@ All notable changes to this project will be documented in this file.
 * Shapes cannot exceeded borders or go through others
 * Shapes are chosen randomly
 * After filling entire row, it is deleted and blocks above fall down by 1 block position
+
+## 05.08.2024
+
+* Removed Debug button as it does nothing interesting
+* Blocks can be rotated with up arrow to the right and Z button to the left
+* Blocks cannot be rotated if there is not enough space for them
+* If block is rotated near obstacle like other block or border of playing field, block is moved to not to be stuck
+ 

--- a/src/Tetris.pro
+++ b/src/Tetris.pro
@@ -25,13 +25,15 @@ SOURCES += \
     main.cpp \
     mainwindow.cpp \
     menu.cpp \
-    scene.cpp
+    scene.cpp \
+    shape.cpp
 
 HEADERS += \
     block.h \
     mainwindow.h \
     menu.h \
-    scene.h
+    scene.h \
+    shape.h
 
 FORMS += \
     mainwindow.ui \

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -25,33 +25,9 @@ void Block::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWi
     painter->fillRect(boundingRect(), fillColor);
 }
 
-int Block::moveDown(qreal step)
+void Block::moveDown()
 {
-    if (scenePos().y() < 760.0)
-    {
-        setPos(pos() + QPointF(0, step));
-    }
-    else
-    {
-        return 1;
-    }
-    return 0;
-}
-
-void Block::moveLeft(qreal step)
-{
-    if (scenePos().x() + 200 > 0.0 && scenePos().y() < 760.0)
-    {
-        setPos(pos() + QPointF(-step, 0));
-    }
-}
-
-void Block::moveRight(qreal step)
-{
-    if (scenePos().x() + 200 < 360.0 && scenePos().y() < 760.0)
-    {
-        setPos(pos() + QPointF(step, 0));
-    }
+    setPos(pos() + QPointF(0, 40));
 }
 
 void Block::changeColor(QColor color)

--- a/src/block.h
+++ b/src/block.h
@@ -12,9 +12,7 @@ class Block : public QGraphicsRectItem
 public:
     explicit Block(QGraphicsItem *parent = nullptr);
 
-    int moveDown(qreal step = 40.0);
-    void moveLeft(qreal step = 40.0);
-    void moveRight(qreal step = 40.0);
+    void moveDown();
     void changeColor(QColor color);
 
 protected:

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -20,10 +20,6 @@ MainWindow::MainWindow(QWidget *parent)
         scene->start();
         view->setFocus();
     });
-    connect(ui->Right_menu, &Menu::stop, scene, [scene, view]() {
-        scene->stop();
-        view->setFocus();
-    });
 }
 
 MainWindow::~MainWindow()

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -8,7 +8,6 @@ Menu::Menu(QWidget *parent) :
     ui->setupUi(this);
 
     connect(ui->StartButton, &QPushButton::clicked, this, &Menu::onStartButtonClicked);
-    connect(ui->StopButton, &QPushButton::clicked, this, &Menu::onStopButtonClicked);
 }
 
 Menu::~Menu()
@@ -19,9 +18,4 @@ Menu::~Menu()
 void Menu::onStartButtonClicked()
 {
     emit start();
-}
-
-void Menu::onStopButtonClicked()
-{
-    emit stop();
 }

--- a/src/menu.h
+++ b/src/menu.h
@@ -17,14 +17,12 @@ public:
 
 private slots:
     void onStartButtonClicked();
-    void onStopButtonClicked();
 
 private:
     Ui::Menu *ui;
 
 signals:
     void start();
-    void stop();
 };
 
 #endif // MENU_H

--- a/src/menu.ui
+++ b/src/menu.ui
@@ -21,13 +21,6 @@
      </property>
     </widget>
    </item>
-   <item>
-    <widget class="QPushButton" name="StopButton">
-     <property name="text">
-      <string>Debug button</string>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <resources/>

--- a/src/scene.h
+++ b/src/scene.h
@@ -1,10 +1,8 @@
 ﻿#ifndef SCENE_H
 #define SCENE_H
 
-#define DOWN 1
-#define LEFT 2
-#define RIGHT 3
 #define FALLING_SPEED 1000
+#define SIZE_OUT_OF_MAP 10
 
 #include "shape.h"
 
@@ -16,6 +14,7 @@ class Scene : public QGraphicsScene
     Q_OBJECT
 public:
     explicit Scene(QObject *parent = nullptr);
+    enum CollisionDirection { NONE, DOWN, LEFT, RIGHT, UP };
 
     void start();
     void stop();
@@ -30,15 +29,20 @@ private:
     void clearRow(QList<Block *> blocks);
     void shiftRowsDown(qreal deletedRowPosition);
 
+    void checkCollisions(CollisionDirection directionBorder[], int *numberOfBorderMoves, CollisionDirection *directionBlock, int *numberOfBlockMoves);
+    void putRotationBack(CollisionDirection directionBorder[], int numberOfBorderMoves, CollisionDirection directionBlock, int numberOfBlockMoves, bool backwards = true);
+
     QTimer *mTimer;
     Shape *mShape;
     bool isDropping;
 
     bool isCollision(int direction = DOWN);
     void smallMoveToCollisionDetection(int direction, qreal step);
+    Scene::CollisionDirection isAlreadyBorderCollision();
+    Scene::CollisionDirection isAlreadyBlockCollision();
 
     QList<Block *> blocks;
-    QList<QGraphicsLineItem *> borders;
+    QList<QGraphicsRectItem *> borders;
     QList<QGraphicsLineItem *> rows;
 };
 

--- a/src/scene.h
+++ b/src/scene.h
@@ -1,4 +1,4 @@
-#ifndef SCENE_H
+﻿#ifndef SCENE_H
 #define SCENE_H
 
 #define DOWN 1
@@ -6,7 +6,7 @@
 #define RIGHT 3
 #define FALLING_SPEED 1000
 
-#include "block.h"
+#include "shape.h"
 
 #include <QGraphicsScene>
 #include <QList>
@@ -25,15 +25,21 @@ protected:
 
 private:
     void timeout();
+    Shape::ShapeType nextType();
+    void checkFullRows();
+    void clearRow(QList<Block *> blocks);
+    void shiftRowsDown(qreal deletedRowPosition);
 
     QTimer *mTimer;
-    Block *mBlock;
+    Shape *mShape;
     bool isDropping;
 
     bool isCollision(int direction = DOWN);
     void smallMoveToCollisionDetection(int direction, qreal step);
 
     QList<Block *> blocks;
+    QList<QGraphicsLineItem *> borders;
+    QList<QGraphicsLineItem *> rows;
 };
 
 #endif // SCENE_H

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -14,28 +14,30 @@ Shape::Shape(ShapeType type, QGraphicsItem *parent)
     blocks.append(new Block(this));
     blocks.append(new Block(this));
 
-    // Arrange blocks
-    blocks[0]->setPos(0, 0);
+    // Arrange blocks (blocks[0] will be pivot during rotations)
     switch (type)
     {
         case I:
-            blocks[1]->setPos(-40, 0);
-            blocks[2]->setPos(-80, 0);
+            blocks[0]->setPos(-40, 0);
+            blocks[1]->setPos(-80, 0);
+            blocks[2]->setPos(0, 0);
             blocks[3]->setPos(40, 0);
             break;
         case O:
+            blocks[0]->setPos(0, 0);
             blocks[1]->setPos(-40, 0);
             blocks[2]->setPos(0, 40);
             blocks[3]->setPos(-40, 40);
             break;
         case T:
-            blocks[0]->setPos(-40, 0);
-            blocks[1]->setPos(-40, 40);
+            blocks[0]->setPos(-40, 40);
+            blocks[1]->setPos(0, 40);
             blocks[2]->setPos(-80, 40);
-            blocks[3]->setPos(0, 40);
+            blocks[3]->setPos(-40, 0);
             break;
         case S:
-            blocks[1]->setPos(-40, 0);
+            blocks[0]->setPos(-40, 0);
+            blocks[1]->setPos(0, 0);
             blocks[2]->setPos(-80, 40);
             blocks[3]->setPos(-40, 40);
             break;
@@ -46,15 +48,16 @@ Shape::Shape(ShapeType type, QGraphicsItem *parent)
             blocks[3]->setPos(0, 40);
             break;
         case J:
-            blocks[0]->setPos(-80, 0);
+            blocks[0]->setPos(-40, 40);
             blocks[1]->setPos(-80, 40);
-            blocks[2]->setPos(-40, 40);
-            blocks[3]->setPos(0, 40);
+            blocks[2]->setPos(0, 40);
+            blocks[3]->setPos(-80, 0);
             break;
         case L:
+            blocks[0]->setPos(-40, 40);
             blocks[1]->setPos(0, 40);
-            blocks[2]->setPos(-40, 40);
-            blocks[3]->setPos(-80, 40);
+            blocks[2]->setPos(-80, 40);
+            blocks[3]->setPos(0, 0);
             break;
     }
 
@@ -85,6 +88,11 @@ void Shape::moveRight(qreal step)
     setPos(pos() + QPointF(step, 0));
 }
 
+void Shape::moveUp(qreal step)
+{
+    setPos(pos() + QPointF(0, -step));
+}
+
 void Shape::changeColor(QColor color)
 {
     for (Block *block : blocks)
@@ -94,7 +102,45 @@ void Shape::changeColor(QColor color)
     }
 }
 
+void Shape::rotateBackwards()
+{
+    if (mType == ShapeType::O)
+    {
+        return;
+    }
+
+    QPointF pivotBlock = blocks[0]->pos();
+    for (Block *block : blocks)
+    {
+        QPointF relativePos = block->pos() - pivotBlock;
+
+        qreal newX = -relativePos.y();
+        qreal newY = relativePos.x();
+
+        block->setPos(pivotBlock + QPointF(newX, newY));
+    }
+}
+
 void Shape::rotate()
 {
-    //TODO
+    if (mType == ShapeType::O)
+    {
+        return;
+    }
+
+    QPointF pivotBlock = blocks[0]->pos();
+    for (Block *block : blocks)
+    {
+        QPointF relativePos = block->pos() - pivotBlock;
+
+        qreal newX = relativePos.y();
+        qreal newY = -relativePos.x();
+
+        block->setPos(pivotBlock + QPointF(newX, newY));
+    }
+}
+
+Shape::ShapeType Shape::getShapeType() const
+{
+    return mType;
 }

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -1,0 +1,100 @@
+#include "shape.h"
+
+#include <QPainter>
+#include <QDebug>
+#include <QPen>
+#include <QColor>
+
+Shape::Shape(ShapeType type, QGraphicsItem *parent)
+    : QGraphicsItemGroup(parent),
+      mType(type)
+{
+    blocks.append(new Block(this));
+    blocks.append(new Block(this));
+    blocks.append(new Block(this));
+    blocks.append(new Block(this));
+
+    // Arrange blocks
+    blocks[0]->setPos(0, 0);
+    switch (type)
+    {
+        case I:
+            blocks[1]->setPos(-40, 0);
+            blocks[2]->setPos(-80, 0);
+            blocks[3]->setPos(40, 0);
+            break;
+        case O:
+            blocks[1]->setPos(-40, 0);
+            blocks[2]->setPos(0, 40);
+            blocks[3]->setPos(-40, 40);
+            break;
+        case T:
+            blocks[0]->setPos(-40, 0);
+            blocks[1]->setPos(-40, 40);
+            blocks[2]->setPos(-80, 40);
+            blocks[3]->setPos(0, 40);
+            break;
+        case S:
+            blocks[1]->setPos(-40, 0);
+            blocks[2]->setPos(-80, 40);
+            blocks[3]->setPos(-40, 40);
+            break;
+        case Z:
+            blocks[0]->setPos(-40, 0);
+            blocks[1]->setPos(-80, 0);
+            blocks[2]->setPos(-40, 40);
+            blocks[3]->setPos(0, 40);
+            break;
+        case J:
+            blocks[0]->setPos(-80, 0);
+            blocks[1]->setPos(-80, 40);
+            blocks[2]->setPos(-40, 40);
+            blocks[3]->setPos(0, 40);
+            break;
+        case L:
+            blocks[1]->setPos(0, 40);
+            blocks[2]->setPos(-40, 40);
+            blocks[3]->setPos(-80, 40);
+            break;
+    }
+
+    // Add blocks to the group
+    for (Block *block : blocks)
+    {
+        addToGroup(block);
+    }
+}
+
+QList<Block *> Shape::getBlocks() const
+{
+    return blocks;
+}
+
+void Shape::moveDown(qreal step)
+{
+    setPos(pos() + QPointF(0, step));
+}
+
+void Shape::moveLeft(qreal step)
+{
+    setPos(pos() + QPointF(-step, 0));
+}
+
+void Shape::moveRight(qreal step)
+{
+    setPos(pos() + QPointF(step, 0));
+}
+
+void Shape::changeColor(QColor color)
+{
+    for (Block *block : blocks)
+    {
+        block->changeColor(color);
+        update();
+    }
+}
+
+void Shape::rotate()
+{
+    //TODO
+}

--- a/src/shape.h
+++ b/src/shape.h
@@ -1,0 +1,29 @@
+#ifndef SHAPE_H
+#define SHAPE_H
+
+#include <QGraphicsItemGroup>
+#include <QList>
+
+#include "block.h"
+
+class Shape : public QGraphicsItemGroup
+{
+public:
+    enum ShapeType { I, O, T, S, Z, J, L };
+
+    explicit Shape(ShapeType type, QGraphicsItem *parent = nullptr);
+
+    QList<Block *> getBlocks() const;
+
+    void moveDown(qreal step = 40.0);
+    void moveLeft(qreal step = 40.0);
+    void moveRight(qreal step = 40.0);
+    void changeColor(QColor color);
+    void rotate();
+
+private:
+    QList<Block *> blocks;
+    ShapeType mType;
+};
+
+#endif // SHAPE_H

--- a/src/shape.h
+++ b/src/shape.h
@@ -10,16 +10,20 @@ class Shape : public QGraphicsItemGroup
 {
 public:
     enum ShapeType { I, O, T, S, Z, J, L };
+    enum CollisionDirection { NONE, DOWN, LEFT, RIGHT, UP };
 
     explicit Shape(ShapeType type, QGraphicsItem *parent = nullptr);
 
     QList<Block *> getBlocks() const;
+    Shape::ShapeType getShapeType() const;
 
     void moveDown(qreal step = 40.0);
     void moveLeft(qreal step = 40.0);
     void moveRight(qreal step = 40.0);
+    void moveUp(qreal step = 40.0);
     void changeColor(QColor color);
     void rotate();
+    void rotateBackwards();
 
 private:
     QList<Block *> blocks;


### PR DESCRIPTION
Added shapes to make it looks like Tetris. Of course you can stack them and make tower or you can try to fill entire playing field. After filling entire row, it is removed and blocks above fall down. To make it easier for different shapes to fit positions where they fit almost perfectly, there are rotations. You can rotate with pieces just with up arrow on your keyboard or Z button. Z button rotates piece to the left and up arrow to the right.